### PR TITLE
use "region" as default temp face

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -190,8 +190,7 @@ SCOPE, `symbol-overlay-narrow-function' and WINDOW."
 	  (narrow-to-region beg (point)))))))
 
 (defvar symbol-overlay-temp-face
-  '((:background "gray70")
-    (:foreground "gray30"))
+  'region
   "Face for temporary highlighting.")
 
 (defun symbol-overlay-put-temp-one (symbol bounds)


### PR DESCRIPTION
The default `symbol-overlay-temp-face` is "gray", which is not suitable for some light color theme. Alternatively, `region` is a better choice. (But user will be confused when they try to mark a word, because the region color is the same as `symbol-overlay-temp-face` )

Refer to [idle-highlight-mode](https://github.com/nonsequitur/idle-highlight-mode/blob/master/idle-highlight-mode.el#L63)