### PR TITLE
Add missing parens in face definition

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -199,7 +199,7 @@ SCOPE and WINDOW."
 	  (narrow-to-region beg (point)))))))
 
 (defface symbol-overlay-temp-face
-  '(t (:inherit 'highlight))
+  '((t (:inherit 'highlight)))
   "Face for temporary highlighting.")
 
 (defun symbol-overlay-remove-temp ()


### PR DESCRIPTION
Hi, really sorry about this - I missed a set of parens, so the default face definition was broken, and caused errors at load-time. A quick merge of this fix should resolve the problem.