### PR TITLE
When renaming, don't add coloured highlight if there wasn't previously one

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -520,14 +520,16 @@ DIR must be 1 or -1."
                              (substring symbol 3 -3))
 	    new (symbol-overlay-get-symbol txt))
       (unless (string= new symbol)
-	(symbol-overlay-maybe-remove (symbol-overlay-assoc new))
-	(save-excursion
-	  (save-restriction
-	    (symbol-overlay-narrow scope)
-	    (goto-char (point-min))
-	    (let ((inhibit-modification-hooks t))
-	      (while (re-search-forward symbol nil t) (replace-match txt t)))))
-	(setq keyword (symbol-overlay-put-all new scope keyword)))
+        (let ((prev-overlay (symbol-overlay-assoc new)))
+	  (symbol-overlay-maybe-remove prev-overlay)
+	  (save-excursion
+	    (save-restriction
+	      (symbol-overlay-narrow scope)
+	      (goto-char (point-min))
+	      (let ((inhibit-modification-hooks t))
+	        (while (re-search-forward symbol nil t) (replace-match txt t)))))
+          (when prev-overlay
+	    (setq keyword (symbol-overlay-put-all new scope keyword)))))
       (when (string= new (symbol-overlay-get-symbol nil t))
 	(symbol-overlay-maybe-count keyword)))))
 


### PR DESCRIPTION
I don't use coloured symbol overlays, but I use lazy highlighting and `symbol-overlay-rename`. After renaming, that function adds a coloured overlay, where none previously existed. With this commit, a new coloured overlay is added only if there was one prior to renaming, which reduces the friction of this function in my use case.