### PR TITLE
Do not enable symbol-overlay-mode when keyword not found

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -384,11 +384,9 @@ DIR must be 1 or -1."
 	   (keyword (symbol-overlay-assoc symbol)))
       (push-mark nil t)
       (funcall jump-function symbol dir)
-      (if keyword
-          (progn
-            (symbol-overlay-maybe-reput symbol keyword)
-            (symbol-overlay-maybe-count keyword))
-        (symbol-overlay-mode)))))
+      (when keyword
+        (symbol-overlay-maybe-reput symbol keyword)
+        (symbol-overlay-maybe-count keyword)))))
 
 (defun symbol-overlay-basic-jump (symbol dir)
   "Jump to SYMBOL's next location in the direction DIR.  DIR must be 1 or -1."


### PR DESCRIPTION
The problem I have was that `symbol-overlay-mode` will be auto enabled when I call `symbol-overlay-jump-prev` or `symbol-overlay-jump-prev` without highlighting any symbol.

Don't know if this will break anything, so please have a look. And thanks for the great work!