### PR TITLE
add faces, replace color logic with face logic

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -84,6 +84,76 @@
   "Highlight symbols with keymap-enabled overlays."
   :group 'convenience)
 
+(defface symbol-overlay-default-face
+  '((t (:box (:line-width -1))))
+  "Symbol Overlay default face")
+
+
+(defface symbol-overlay-face-1
+  '((t (:box (:line-width -1 :color "dodger blue"))))
+  "Symbol Overlay default candidate 1")
+
+(defface symbol-overlay-face-2
+  '((t (:box (:line-width -1 :color "hot pink"))))
+  "Symbol Overlay default candidate 2")
+
+(defface symbol-overlay-face-3
+  '((t (:box (:line-width -1 :color "yellow"))))
+  "Symbol Overlay default candidate 3")
+
+(defface symbol-overlay-face-4
+  '((t (:box (:line-width -1 :color "orchid"))))
+  "Symbol Overlay default candidate 4")
+
+(defface symbol-overlay-face-5
+  '((t (:box (:line-width -1 :color "red"))))
+  "Symbol Overlay default candidate 5")
+
+(defface symbol-overlay-face-6
+  '((t (:box (:line-width -1 :color "salmon"))))
+  "Symbol Overlay default candidate 6")
+
+(defface symbol-overlay-face-7
+  '((t (:box (:line-width -1 :color "spring green"))))
+  "Symbol Overlay default candidate 7")
+
+(defface symbol-overlay-face-8
+  '((t (:box (:line-width -1 :color "turquoise"))))
+  "Symbol Overlay default candidate 8")
+
+(defcustom symbol-overlay-faces '(symbol-overlay-face-1
+                                  symbol-overlay-face-2
+                                  symbol-overlay-face-3
+                                  symbol-overlay-face-4
+                                  symbol-overlay-face-5
+                                  symbol-overlay-face-6
+                                  symbol-overlay-face-7
+                                  symbol-overlay-face-8)
+  "Faces used for overlays."
+  :type '(repeat face)
+  :group 'symbol-overlay
+  )
+
+(defcustom symbol-overlay-colors
+  '("dodger blue"
+    "hot pink"
+    "orange"
+    "orchid"
+    "red"
+    "salmon"
+    "spring green"
+    "turquoise")
+  "Colors used for overlays' background.
+You can add more colors whatever you like."
+  :type '(repeat string)
+  :group 'symbol-overlay
+  )
+
+(defcustom symbol-overlay-idle-time 0.5
+  "Idle time after every command and before the temporary highlighting."
+  :group 'symbol-overlay
+  :type 'float)
+
 (defvar symbol-overlay-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "i") 'symbol-overlay-put)
@@ -101,21 +171,6 @@
 You can re-bind the commands to any keys you prefer.")
 
 (defvar-local symbol-overlay-keywords-alist nil)
-
-(defcustom symbol-overlay-colors '("dodger blue"
-                                   "hot pink"
-                                   "orange"
-                                   "orchid"
-                                   "red"
-                                   "salmon"
-                                   "spring green"
-                                   "turquoise")
-  "Colors used for overlays' background.
-You can add more colors whatever you like.")
-
-(defcustom symbol-overlay-idle-time 0.5
-  "Idle time after every command and before the temporary highlighting."
-  :type 'float)
 
 ;;;###autoload
 (define-minor-mode symbol-overlay-mode
@@ -198,10 +253,6 @@ depending on SCOPE and WINDOW."
 	  (forward-line lines)
 	  (narrow-to-region beg (point)))))))
 
-(defface symbol-overlay-temp-face
-  '((t (:inherit 'highlight)))
-  "Face for temporary highlighting.")
-
 (defun symbol-overlay-remove-temp ()
   "Delete all temporary overlays."
   (mapc 'delete-overlay (symbol-overlay-get-list ""))
@@ -244,42 +295,42 @@ This only effects symbols in the current displayed window."
   (unless (string= (symbol-overlay-get-symbol nil t) symbol-overlay-temp-symbol)
     (symbol-overlay-remove-temp)))
 
-(defun symbol-overlay-put-one (symbol &optional color)
+(defun symbol-overlay-put-one (symbol &optional face)
   "Put overlay on current occurrence of SYMBOL after a match.
-If COLOR is non-nil, use it as the overlay face's background color.
-Otherwise use `symbol-overlay-temp-face' as the face."
+If FACE is non-nil, use it as the overlay’s face.
+Otherwise apply `symbol-overlay-default-face'."
   (let ((ov (make-overlay (match-beginning 0) (match-end 0))))
-    (if color (progn (overlay-put ov 'face `(:background ,color :foreground "black"))
-		     (overlay-put ov 'keymap symbol-overlay-map)
-		     (overlay-put ov 'evaporate t)
-		     (overlay-put ov 'symbol symbol))
-      (overlay-put ov 'face 'symbol-overlay-temp-face)
+    (if face (progn (overlay-put ov 'face face)
+		    (overlay-put ov 'keymap symbol-overlay-map)
+		    (overlay-put ov 'evaporate t)
+		    (overlay-put ov 'symbol symbol))
+      (overlay-put ov 'face 'symbol-overlay-default-face)
       (overlay-put ov 'symbol ""))))
 
 (defun symbol-overlay-put-all (symbol scope &optional keyword)
   "Put overlays on all occurrences of SYMBOL in the buffer.
-The background color is randomly picked from `symbol-overlay-colors'.
+The face is randomly picked from `symbol-overlay-faces'.
 If SCOPE is non-nil, put overlays only on occurrences in scope.
 If KEYWORD is non-nil, remove it then use its color on new overlays."
   (let* ((case-fold-search nil)
-	 (limit (length symbol-overlay-colors))
-	 (color (or (symbol-overlay-maybe-remove keyword)
-		    (elt symbol-overlay-colors (random limit))))
+	 (limit (length symbol-overlay-faces))
+	 (face (or (symbol-overlay-maybe-remove keyword)
+	           (elt symbol-overlay-faces (random limit))))
 	 (alist symbol-overlay-keywords-alist)
-	 (colors (mapcar 'cddr alist))
+	 (faces (mapcar 'cddr alist))
 	 (pt (point)))
     (if (< (length alist) limit)
-	(while (seq-position colors color)
-	  (setq color (elt symbol-overlay-colors (random limit))))
-      (setq color (symbol-overlay-maybe-remove (car (last alist)))))
+	(while (seq-position faces face)
+	  (setq face (elt symbol-overlay-faces (random limit))))
+      (setq face (symbol-overlay-maybe-remove (car (last alist)))))
     (and symbol-overlay-temp-symbol (symbol-overlay-remove-temp))
     (save-excursion
       (save-restriction
 	(symbol-overlay-narrow scope)
 	(goto-char (point-min))
 	(while (re-search-forward symbol nil t)
-	  (symbol-overlay-put-one symbol color))))
-    (setq keyword `(,symbol ,scope . ,color))
+	  (symbol-overlay-put-one symbol face))))
+    (setq keyword `(,symbol ,scope . ,face))
     (push keyword symbol-overlay-keywords-alist)
     keyword))
 


### PR DESCRIPTION
1. Set up customizeable faces

2. Change the internal overlay creation to use faces

3. Change the primary face attribute to ":box" from ":background" by default because :background is used by other packages (and region).

The first two are pretty seamless. The last one might be a step too far since it changes your look and feel but using :background was stopping me from using the package. If you'd like me to change it back to using :background by default, I'd be happy to. 

Cheers.