### PR TITLE
Fix error in symbol-overlay-ignore-function-python

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -389,7 +389,11 @@ If SHOW-COLOR is non-nil, display the color used by current overlay."
 (defvar python-font-lock-keywords)
 (defun symbol-overlay-ignore-function-python (symbol)
   "Determine whether SYMBOL should be ignored (Python)."
-  (string-match-p (car python-font-lock-keywords) symbol))
+  (let* ((keyword-symbol (car python-font-lock-keywords))
+         (keyword (if (stringp keyword-symbol)
+                      keyword-symbol
+                    (symbol-name keyword-symbol))))
+    (string-match-p keyword symbol)))
 
 ;;;###autoload
 (defun symbol-overlay-put ()


### PR DESCRIPTION
On emacs master, python-font-lock-keywords is now a list of symbols, not a list of strings.

Fixes #25.