### PR TITLE
Replaced lisp implementation of window start and end with C primitive

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -274,15 +274,7 @@ depending on SCOPE and WINDOW."
                        max (progn (forward-paragraph) (point))))
           (narrow-to-region min max)))
     (when window
-      (let ((lines (round (window-screen-lines)))
-            (pt (point))
-            beg)
-        (save-excursion
-          (forward-line (- lines))
-          (setq beg (point))
-          (goto-char pt)
-          (forward-line lines)
-          (narrow-to-region beg (point)))))))
+      (narrow-to-region (window-start) (window-end)))))
 
 (defun symbol-overlay-remove-temp ()
   "Delete all temporary overlays."


### PR DESCRIPTION
Currently `symbol-overlay-maybe-put-temp` uses `save-excursion` to move the cursor around to get the window size. Emacs comes with a C primitive to do this which is a lot faster in the short tests I did
![quick-bench](https://user-images.githubusercontent.com/2865774/58373255-5e10ee80-7f2b-11e9-975a-45eea38ab4f9.png)

I'm not sure when these were added so maybe the required emacs version will be wrong after this change