### PR TITLE
symbol-overlay-idle-time can now be nil without error for instant highlighting

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -152,7 +152,9 @@
   :type 'boolean)
 
 (defcustom symbol-overlay-idle-time 0.5
-  "Idle time after every command and before the temporary highlighting."
+  "Idle time after every command and before the temporary highlighting.
+
+If nil highlighting is instant"
   :group 'symbol-overlay
   :type 'float)
 
@@ -209,7 +211,8 @@ You can re-bind the commands to any keys you prefer.")
   (if symbol-overlay-mode
       (progn
         (add-hook 'post-command-hook 'symbol-overlay-post-command nil t)
-        (symbol-overlay-update-timer symbol-overlay-idle-time))
+        (when symbol-overlay-idle-time
+          (symbol-overlay-update-timer symbol-overlay-idle-time)))
     (remove-hook 'post-command-hook 'symbol-overlay-post-command t)
     (symbol-overlay-remove-temp)))
 
@@ -334,7 +337,9 @@ This only effects symbols in the current displayed window if
 (defun symbol-overlay-post-command ()
   "Installed on `post-command-hook'."
   (unless (string= (symbol-overlay-get-symbol nil t) symbol-overlay-temp-symbol)
-    (symbol-overlay-remove-temp)))
+    (symbol-overlay-remove-temp)
+    (unless symbol-overlay-idle-time
+      (symbol-overlay-maybe-put-temp))))
 
 (defun symbol-overlay-put-one (symbol &optional face)
   "Put overlay on current occurrence of SYMBOL after a match.

--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -154,7 +154,8 @@
 (defcustom symbol-overlay-idle-time 0.5
   "Idle time after every command and before the temporary highlighting.
 
-If nil highlighting is instant"
+If nil highlighting is instant but you have to set it to nil before 
+enabling `symbol-overlay-mode' for it to work properly"
   :group 'symbol-overlay
   :type 'float)
 


### PR DESCRIPTION
I want the highlighting to be instant but if i set symbol-overlay-idle-time to 0 it doesn't work, if I set it to nil i get an error and if I set it to 0.001 it spams the highlight function leading to lots garbage collections even when i'm not doing anything. This makes it run the highlighting function every keypress if symbol-overlay-idle-time is nil and the selected word has changed. A problem with this is that you have to set it to nil before enabling the mode for this to work as intended, but I'm not sure if this is worth fixing