### PR TITLE
Add a hook for when overlays are created

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -156,6 +156,12 @@
   :group 'symbol-overlay
   :type 'float)
 
+(defcustom symbol-overlay-cursor-hook
+  '(lambda (window oldpos entered-or-left) '())
+  "A function that is put in the cursor-sensor-functions on every overlay."
+  :group 'symbol-overlay
+  :type 'hook)
+
 (defcustom symbol-overlay-ignore-functions
   '((c-mode . symbol-overlay-ignore-function-c)
     (c++-mode . symbol-overlay-ignore-function-c++)
@@ -336,7 +342,10 @@ Otherwise apply `symbol-overlay-default-face'."
     (if face (progn (overlay-put ov 'face face)
                     (overlay-put ov 'keymap symbol-overlay-map)
                     (overlay-put ov 'evaporate t)
-                    (overlay-put ov 'symbol symbol))
+                    (overlay-put ov 'symbol symbol)
+                    (overlay-put ov
+                                 'cursor-sensor-functions
+                                 `(,symbol-overlay-cursor-hook)))
       (overlay-put ov 'face 'symbol-overlay-default-face)
       (overlay-put ov 'symbol ""))))
 

--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -156,9 +156,8 @@
   :group 'symbol-overlay
   :type 'float)
 
-(defcustom symbol-overlay-cursor-hook
-  '(lambda (window oldpos entered-or-left) '())
-  "A function that is put in the cursor-sensor-functions on every overlay."
+(defcustom symbol-overlay-overlay-created-functions '()
+  "Functions called after overlay creation that may modify the overlay."
   :group 'symbol-overlay
   :type 'hook)
 
@@ -342,12 +341,11 @@ Otherwise apply `symbol-overlay-default-face'."
     (if face (progn (overlay-put ov 'face face)
                     (overlay-put ov 'keymap symbol-overlay-map)
                     (overlay-put ov 'evaporate t)
-                    (overlay-put ov 'symbol symbol)
-                    (overlay-put ov
-                                 'cursor-sensor-functions
-                                 `(,symbol-overlay-cursor-hook)))
+                    (overlay-put ov 'symbol symbol))
       (overlay-put ov 'face 'symbol-overlay-default-face)
-      (overlay-put ov 'symbol ""))))
+      (overlay-put ov 'symbol ""))
+    (dolist (fun symbol-overlay-overlay-created-functions)
+      (funcall fun ov))))
 
 (defun symbol-overlay-put-all (symbol scope &optional keyword)
   "Put overlays on all occurrences of SYMBOL in the buffer.


### PR DESCRIPTION
I'm going to use this to enter what Spacemacs calls a "transient state", rather than using the keymap (which is confusing when combined with Spacemacs/Evil modal keybindings).  

I don't think we actually need to require `cursor-sensor` for this to work? Can we just add the property anyway? 