### PR TITLE
Fix format error while marking a symbol contains "%"

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -398,10 +398,10 @@ If SHOW-COLOR is non-nil, display the color used by current overlay."
            (count (length before))
            ;; Log to echo area but not *Messages*
            message-log-max)
-      (message (concat symbol
-                       ": %d/%d"
+      (message (concat "%s: %d/%d"
                        (and (cadr keyword) " in scope")
                        (and show-color (format " (%s)" (cddr keyword))))
+               symbol
                (+ count 1)
                (+ count (length after))))))
 


### PR DESCRIPTION
If the name of a symbol contains "%", it will be recognized as format string template accidently in function `symbol-overlay-maybe-count`. This PR fix this.

* symbol-overlay.el(symbol-overlay-maybe-count): Escape symbol in format string.