### PR TITLE
Add a knob, `symbol-overlay-temp-highlight-single', to allow applying temp highlighting to single occurences.

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -152,8 +152,7 @@
   :type 'boolean)
 
 (defcustom symbol-overlay-temp-highlight-single nil
-  "When non-nil, also apply temporary highlighting to symbols
-that occur only once."
+  "When non-nil, also temporarily highlight symbols that occur only once."
   :group 'symbol-overlay
   :type 'boolean)
 

--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -151,6 +151,12 @@
   :group 'symbol-overlay
   :type 'boolean)
 
+(defcustom symbol-overlay-temp-highlight-single nil
+  "When non-nil, also apply temporary highlighting to symbols
+that occur only once."
+  :group 'symbol-overlay
+  :type 'boolean)
+
 (defcustom symbol-overlay-idle-time 0.5
   "Idle time after every command and before the temporary highlighting."
   :group 'symbol-overlay
@@ -321,7 +327,7 @@ This only affects symbols in the current displayed window if
                 (while (re-search-forward re nil t)
                   (symbol-overlay-put-one symbol)
                   (or p (setq p t))))
-              (when p
+              (when (or symbol-overlay-temp-highlight-single p)
                 (symbol-overlay-put-one symbol)
                 (setq symbol-overlay-temp-symbol symbol)))))))))
 


### PR DESCRIPTION
This was discussed in #38.

Personally, I also prefer not taking occurrence into account when applying temp highlighting, for the consistency in behavior -- when temp highlighting fails to show up for the current symbol, my first reaction is not "oh this symbol only occurs once", but more like "did i forget to turn symbol-overlay-mode on for this buffer?", "is my Emacs broken again?", etc., which gives me a lot of undesirable anxiety :) 