### PR TITLE
Avoid positional arguments to define-minor-mode

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -216,10 +216,14 @@ You can re-bind the commands to any keys you prefer.")
       (with-current-buffer buf
         (insert (substitute-command-keys "\\{symbol-overlay-map}"))))))
 
+(defvar symbol-overlay-mode-map (make-sparse-keymap)
+  "Keymap for `symbol-overlay-mode'.")
+
 ;;;###autoload
 (define-minor-mode symbol-overlay-mode
   "Minor mode for auto-highlighting symbol at point."
-  nil " SO" (make-sparse-keymap)
+  :lighter " SO"
+  :keymap symbol-overlay-mode-map
   (if symbol-overlay-mode
       (progn
         (add-hook 'post-command-hook 'symbol-overlay-post-command nil t)


### PR DESCRIPTION
Back in Emacs-21.1, `define-minor-mode` grew keyword arguments to
replace its old positional arguments.  Starting with Emacs-28.1
warning will be omitted if positional arguments are still used.