### PR TITLE
Cancel a buffer’s ‘symbol-overlay-cancel-timer’ when it is killed

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -227,6 +227,7 @@ You can re-bind the commands to any keys you prefer.")
   (if symbol-overlay-mode
       (progn
         (add-hook 'post-command-hook 'symbol-overlay-post-command nil t)
+        (add-hook 'kill-buffer-hook 'symbol-overlay-cancel-timer)
         (symbol-overlay-update-timer symbol-overlay-idle-time))
     (remove-hook 'post-command-hook 'symbol-overlay-post-command t)
     (symbol-overlay-cancel-timer)


### PR DESCRIPTION
Hi there,
I've been using this package for a while but have noticed that it can lead to slowdowns over time, particularly after a large number of buffers has been opened.  In one Emacs sessions I have going at the moment, I have had hundreds of buffers open, and there are over 500 instances of 'symbol-overlay-cancel-timer', mostly for killed buffers, still present in 'timer-idle-list'.  This causes a noticeable pause every so often while editing.  Adding 'symbol-overlay-cancel-timer' to 'kill-buffer-hook' when the minor mode is enabled fixes this.

Thanks,
Matt