### PR TITLE
Use a single shared timer for all buffers

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -227,10 +227,8 @@ You can re-bind the commands to any keys you prefer.")
   (if symbol-overlay-mode
       (progn
         (add-hook 'post-command-hook #'symbol-overlay-post-command nil t)
-        (add-hook 'kill-buffer-hook #'symbol-overlay-cancel-timer)
         (symbol-overlay-update-timer symbol-overlay-idle-time))
     (remove-hook 'post-command-hook #'symbol-overlay-post-command t)
-    (symbol-overlay-cancel-timer)
     (symbol-overlay-remove-temp)))
 
 (defun symbol-overlay-get-list (dir &optional symbol exclude)
@@ -336,7 +334,7 @@ This only affects symbols in the current displayed window if
     (when f
       (funcall f symbol))))
 
-(defvar-local symbol-overlay-timer nil
+(defvar symbol-overlay-timer nil
   "Timer for temporary highlighting.")
 
 (defun symbol-overlay-cancel-timer ()

--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -342,21 +342,18 @@ This only affects symbols in the current displayed window if
   (when symbol-overlay-timer
     (cancel-timer symbol-overlay-timer)))
 
-(defun symbol-overlay-idle-timer (buf)
-  "Idle timer callback for BUF.
-This is used to maybe highlight the symbol at point, but only if
-the buffer is visible in the currently-selected window at the
-time."
-  (when (and (buffer-live-p buf) (eq (window-buffer) buf))
-    (with-current-buffer buf
-      (symbol-overlay-maybe-put-temp))))
+(defun symbol-overlay-idle-timer ()
+  "Idle timer callback.
+This is used to maybe highlight the symbol at point in whichever
+buffer happens to be current when the timer is fired."
+  (symbol-overlay-maybe-put-temp))
 
 (defun symbol-overlay-update-timer (value)
   "Update `symbol-overlay-timer' with new idle-time VALUE."
   (symbol-overlay-cancel-timer)
   (setq symbol-overlay-timer
         (and value (> value 0)
-             (run-with-idle-timer value t #'symbol-overlay-idle-timer (current-buffer)))))
+             (run-with-idle-timer value t #'symbol-overlay-idle-timer))))
 
 (defun symbol-overlay-post-command ()
   "Installed on `post-command-hook'."


### PR DESCRIPTION
Hi there, this PR causes all buffers using Symbol Overlay mode to share a single timer, rather than creating a separate timer for each buffer the mode is active in.  In my testing it doesn't seem to have any effect other than reducing the number of active timers in `timer-idle-list` (potentially by a large number if, like me, you have a ton of buffers open all the time, most of them using this mode).