### PR TITLE
Add symbol-overlay-jump-hook

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -184,6 +184,11 @@ prioritise `symbol-overlay' relative to `flymake' or other features."
   :group 'symbol-overlay
   :type 'integer)
 
+(defcustom symbol-overlay-jump-hook nil
+  "Hook to run after jumping to a symbol."
+  :group 'symbol-overlay
+  :type 'hook)
+
 ;;; Internal
 
 (defvar symbol-overlay-inhibit-map nil
@@ -647,6 +652,7 @@ DIR must be non-zero."
            (keyword (symbol-overlay-assoc symbol)))
       (push-mark nil t)
       (funcall jump-function symbol dir)
+      (run-hooks 'symbol-overlay-jump-hook)
       (when keyword
         (symbol-overlay-maybe-reput symbol keyword)
         (symbol-overlay-maybe-count keyword)))))


### PR DESCRIPTION
This PR adds `symbol-overlay-jump-hook` custom variable, which lets the user configure functions to run after jumping to a function.

For example, the following hook expands an Org entry surrounding the destination symbol in `org-mode`:

```emacs-lisp
(add-hook 'symbol-overlay-jump-hook
          (lambda ()
            (when (derived-mode-p 'org-mode)
              (org-show-entry))))
```

Note that this does not apply to commands using `symbol-overlay-switch-symbol`. It only applies to jumps.