### PR TITLE
Update for Emacs 29

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -236,16 +236,16 @@ You can re-bind the commands to any keys you prefer.")
 If SYMBOL is non-nil, get the overlays that belong to it.
 DIR is an integer.
 If EXCLUDE is non-nil, get all overlays excluding those belong to SYMBOL."
-  (let ((overlays (overlays-in (point-min) (point-max))))
-    (if (= dir 0)
-        overlays
+  (if (= dir 0)
+      (overlays-in (point-min) (point-max))
+    (let ((overlays (cond ((< dir 0) (overlays-in (point-min) (point)))
+                          ((> dir 0) (overlays-in (point) (point-max))))))
       (seq-filter
        (lambda (ov)
          (let ((value (overlay-get ov 'symbol))
-               (start (overlay-start ov)))
+               (end (overlay-end ov)))
            (and value
-                (if (> dir 0) (<= (point) start)
-                  (> (point) start))
+                (if (< dir 0) (< end (point)) t)
                 (or (not symbol)
                     (if (string= value symbol) (not exclude)
                       (and exclude (not (string= value ""))))))))

--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -245,7 +245,7 @@ If EXCLUDE is non-nil, get all overlays excluding those belong to SYMBOL."
          (let ((value (overlay-get ov 'symbol))
                (end (overlay-end ov)))
            (and value
-                (if (< dir 0) (< end (point)) t)
+                (or (> dir 0) (< end (point)))
                 (or (not symbol)
                     (if (string= value symbol) (not exclude)
                       (and exclude (not (string= value ""))))))))

--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -236,17 +236,20 @@ You can re-bind the commands to any keys you prefer.")
 If SYMBOL is non-nil, get the overlays that belong to it.
 DIR is an integer.
 If EXCLUDE is non-nil, get all overlays excluding those belong to SYMBOL."
-  (let ((lists (progn (overlay-recenter (point)) (overlay-lists)))
-        (func (if (> dir 0) 'cdr (if (< dir 0) 'car nil))))
-    (seq-filter
-     (lambda (ov)
-       (let ((value (overlay-get ov 'symbol)))
-         (and value
-              (or (not symbol)
-                  (if (string= value symbol) (not exclude)
-                    (and exclude (not (string= value ""))))))))
-     (if func (funcall func lists)
-       (append (car lists) (cdr lists))))))
+  (let ((overlays (overlays-in (point-min) (point-max))))
+    (if (= dir 0)
+        overlays
+      (seq-filter
+       (lambda (ov)
+         (let ((value (overlay-get ov 'symbol))
+               (start (overlay-start ov)))
+           (and value
+                (if (> dir 0) (<= (point) start)
+                  (> (point) start))
+                (or (not symbol)
+                    (if (string= value symbol) (not exclude)
+                      (and exclude (not (string= value ""))))))))
+       overlays))))
 
 (defun symbol-overlay-get-symbol (&optional noerror)
   "Get the symbol at point.


### PR DESCRIPTION
Rewrite symbol-overlay-get-list to use 'overlays-in' instead of
'overlay-recenter' and 'overlay-lists', which are deprecated and do
not do what they used to do.

Due to the new overlay implementation, symbol-overlay does not show
the correct counts (on the mode-line) on Emacs 29.  This PR fixes this
bug.

This change should be compatible with older Emacs versions as well.