### PR TITLE
Fix get overlays when point is at end of symbol

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -239,7 +239,9 @@ If EXCLUDE is non-nil, get all overlays excluding those belong to SYMBOL."
   (if (= dir 0)
       (overlays-in (point-min) (point-max))
     (let ((overlays (cond ((< dir 0) (overlays-in (point-min) (point)))
-                          ((> dir 0) (overlays-in (point) (point-max))))))
+                          ((> dir 0) (overlays-in 
+                                      (if (looking-at-p "\\_>") (1- (point)) (point))
+                                      (point-max))))))
       (seq-filter
        (lambda (ov)
          (let ((value (overlay-get ov 'symbol))


### PR DESCRIPTION
Because we have a `symbol-overlay-adjust-position` function, so we need to get the previous overlay too when the cursor is at the end.

Before this PR.
![image](https://user-images.githubusercontent.com/13600799/208350536-29b07ee7-f8cc-45bc-ba12-d15079d57c35.png)

After...
![image](https://user-images.githubusercontent.com/13600799/208350614-c74b52eb-d945-4808-b654-8b4034553fb6.png)
