### PR TITLE
Fix symbol-overlay-get-list

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -236,20 +236,19 @@ You can re-bind the commands to any keys you prefer.")
 If SYMBOL is non-nil, get the overlays that belong to it.
 DIR is an integer.
 If EXCLUDE is non-nil, get all overlays excluding those belong to SYMBOL."
-  (if (= dir 0)
-      (overlays-in (point-min) (point-max))
-    (let ((overlays (cond ((< dir 0) (overlays-in (point-min) (point)))
-                          ((> dir 0) (overlays-in (point) (point-max))))))
-      (seq-filter
-       (lambda (ov)
-         (let ((value (overlay-get ov 'symbol))
-               (end (overlay-end ov)))
-           (and value
-                (or (> dir 0) (< end (point)))
-                (or (not symbol)
-                    (if (string= value symbol) (not exclude)
-                      (and exclude (not (string= value ""))))))))
-       overlays))))
+  (let ((overlays (cond ((= dir 0) (overlays-in (point-min) (point-max)))
+                        ((< dir 0) (overlays-in (point-min) (point)))
+                        ((> dir 0) (overlays-in (point) (point-max))))))
+    (seq-filter
+     (lambda (ov)
+       (let ((value (overlay-get ov 'symbol))
+             (end (overlay-end ov)))
+         (and value
+              (or (>= dir 0) (< end (point)))
+              (or (not symbol)
+                  (if (string= value symbol) (not exclude)
+                    (and exclude (not (string= value ""))))))))
+     overlays)))
 
 (defun symbol-overlay-get-symbol (&optional noerror)
   "Get the symbol at point.


### PR DESCRIPTION
The previous version as presented in #86 is incorrect when dir = 0.