### PR TITLE
Improve symbol-overlay-post-command

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -359,7 +359,8 @@ buffer happens to be current when the timer is fired."
 
 (defun symbol-overlay-post-command ()
   "Installed on `post-command-hook'."
-  (unless (string= (symbol-overlay-get-symbol t) symbol-overlay-temp-symbol)
+  (unless (or (null symbol-overlay-temp-symbol)
+              (string= (symbol-overlay-get-symbol t) symbol-overlay-temp-symbol))
     (symbol-overlay-remove-temp)))
 
 (defun symbol-overlay-put-one (symbol &optional face)


### PR DESCRIPTION
symbol-overlay-get-symbol was invoked unnecessarily.
It cost small amount, but since its in post-command-hook, it could pill up.
When profiling I sometimes notice symbol-overlay-get-symbol takes few persent of allocation usage.