### PR TITLE
Use symbol-overlay-faces in order, reuse last face if needed

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -382,20 +382,16 @@ Otherwise apply `symbol-overlay-default-face'."
 
 (defun symbol-overlay-put-all (symbol scope &optional keyword)
   "Put overlays on all occurrences of SYMBOL in the buffer.
-The face is randomly picked from `symbol-overlay-faces'.
+The face is picked from `symbol-overlay-faces'.
 If SCOPE is non-nil, put overlays only on occurrences in scope.
 If KEYWORD is non-nil, remove it then use its color on new overlays."
   (let* ((case-fold-search nil)
-         (limit (length symbol-overlay-faces))
-         (face (or (symbol-overlay-maybe-remove keyword)
-                   (elt symbol-overlay-faces (random limit))))
-         (alist symbol-overlay-keywords-alist)
-         (faces (mapcar #'cddr alist)))
-    (if (< (length alist) limit)
-        (while (seq-position faces face)
-          (setq face (elt symbol-overlay-faces (random limit))))
-      (setq face (symbol-overlay-maybe-remove (car (last alist)))))
-    (and symbol-overlay-temp-symbol (symbol-overlay-remove-temp))
+         (face (or (car (cl-set-difference
+                         symbol-overlay-faces
+                         (mapcar #'cddr symbol-overlay-keywords-alist)))
+                   ;; If we have exhausted the available faces, then just
+                   ;; keep using the last face for all subsequent symbols.
+                   (car (last symbol-overlay-faces)))))
     (save-excursion
       (save-restriction
         (symbol-overlay-narrow scope)


### PR DESCRIPTION
Instead of using a random face from `symbol-overlay-faces`, use the
first face from that list, which is not already used for another
symbol.  This has several advantages.  More work went into theming
the faces at the beginning of the list, so the faces at the end of
the list, which might not have been adjusted for the theme in use
at all, are only used when absolutely necessary.  Also this makes
it possible to theme the same symbol in different buffers, using
the same face.

By default `symbol-overlay-faces` lists only eight faces, which most
of the time is enough, but also not always.  The change described in
the previous paragraph makes it more appealing to cope with that by
just adding more faces to this list.  But with the default value, or
if one only added a handful of additional faces, then one is still
likely to run out of faces at some point.

Previously a face was freed up, behind the users back, by no longer
using it to highlight the symbol it highlighted up to that point, so
that it could be used by the new symbol.  Now we just reuse the last
face in the list for all new symbols, until the user explicitly makes
another face available again.  This behavior is much more predictable.