### PR TITLE
Before adding a permanent overlay, remove temporary overlay

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -385,6 +385,8 @@ Otherwise apply `symbol-overlay-default-face'."
 The face is randomly picked from `symbol-overlay-faces'.
 If SCOPE is non-nil, put overlays only on occurrences in scope.
 If KEYWORD is non-nil, remove it then use its color on new overlays."
+  (when symbol-overlay-temp-symbol
+    (symbol-overlay-remove-temp))
   (let* ((case-fold-search nil)
          (limit (length symbol-overlay-faces))
          (face (or (symbol-overlay-maybe-remove keyword)


### PR DESCRIPTION
Otherwise both overlays remain in effect until the user moves away from the current symbol.