### PR TITLE
Fix symbol-overlay-rename adding redundant overlay

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -388,7 +388,8 @@ If KEYWORD is non-nil, remove it then use its color on new overlays."
   (when symbol-overlay-temp-symbol
     (symbol-overlay-remove-temp))
   (let* ((case-fold-search nil)
-         (face (or (car (cl-set-difference
+         (face (or (symbol-overlay-maybe-remove keyword)
+                   (car (cl-set-difference
                          symbol-overlay-faces
                          (mapcar #'cddr symbol-overlay-keywords-alist)))
                    ;; If we have exhausted the available faces, then just


### PR DESCRIPTION
According to the documentation, if KEYWORD is non-zero, we need to remove it and then use its color for the new overlay.