### PR TITLE
Fix incorrect behavior of symbol-overlay-switch-backward

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -255,7 +255,7 @@ If SYMBOL is non-nil, get the overlays that belong to it.
 DIR is an integer.
 If EXCLUDE is non-nil, get all overlays excluding those belong to SYMBOL."
   (let ((overlays (cond ((= dir 0) (overlays-in (point-min) (point-max)))
-                        ((< dir 0) (overlays-in (point-min) (point)))
+                        ((< dir 0) (nreverse (overlays-in (point-min) (point))))
                         ((> dir 0) (overlays-in
                                     (if (looking-at-p "\\_>") (1- (point)) (point))
                                     (point-max))))))


### PR DESCRIPTION
When executing `symbol-overlay-switch-backward`, it currently jumps to the first overlay in the buffer instead of to the one immediately preceding the cursor.

For `dir > 0`, the function `symbol-overlay-get-list` retrieves overlays positioned after the cursor in sequence. Conversely, when `dir < 0`, it fetches overlays located before the cursor in sequence. Therefore, with `dir < 0`, the appropriate action is to return the last overlay in the list which is just the overlay before the cursor.