### PR TITLE
Bump the version header

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2017 wolray
 
 ;; Author: wolray <wolray@foxmail.com>
-;; Version: 4.1
+;; Version: 4.2
 ;; URL: https://github.com/wolray/symbol-overlay/
 ;; Keywords: faces, matching
 ;; Package-Requires: ((emacs "24.3") (seq "2.2"))


### PR DESCRIPTION
This repository was tagged `4.2` in 2020 (four years ago), but the library header is still at `4.1`. It should be **at least** 4.2. 

For example, [casual-symbol-overlay](https://github.com/kickingvegas/casual-symbol-overlay/blob/main/lisp/casual-symbol-overlay.el) depends on version `4.2` of this package, which is impossible to satisfy unless you install the exact version (which was released four years ago!) from MELPA Stable.