### PR TITLE
Fix Go keywords in go-ts-mode

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -534,15 +534,21 @@ BEG, END and LEN are the beginning, end and length of changed text."
                     (symbol-name keyword-symbol))))
     (string-match-p keyword symbol)))
 
-(defvar go-builtins)
-(defvar go-constants)
-(defvar go-mode-keywords)
 (defun symbol-overlay-ignore-function-go (symbol)
   "Determine whether SYMBOL should be ignored (Go)."
   ;; Remove \_< and \_> so we can string compare with keywords
-  (or (symbol-overlay-match-keyword-list symbol go-builtins)
-      (symbol-overlay-match-keyword-list symbol go-constants)
-      (symbol-overlay-match-keyword-list symbol go-mode-keywords)))
+  (symbol-overlay-match-keyword-list
+   symbol
+   '("any"        "const"       "func"      "map"     "real"
+     "append"     "continue"    "go"        "max"     "recover"
+     "break"      "copy"        "goto"      "min"     "return"
+     "cap"        "default"     "if"        "new"     "select"
+     "case"       "defer"       "imag"      "nil"     "struct"
+     "chan"       "delete"      "import"    "package" "switch"
+     "clear"      "else"        "interface" "panic"   "true"
+     "close"      "fallthrough" "iota"      "print"   "type"
+     "comparable" "false"       "len"       "println" "var"
+     "complex"    "for"         "make"      "range")))
 
 ;; From https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html
 (defun symbol-overlay-ignore-function-java (symbol)


### PR DESCRIPTION
Emacs 30 is delivered with go-ts-mode. Should user chose to use it (as a
replacement to external package
[go-mode](https://github.com/dominikh/go-mode.el)) the variables `go-builtins`,
`go-constants`, and `go-mode-keywords` are not defined.  This results with
error messages:

```
reference to free variable `go-builtins'
```

The `go-ts-mode` only defines `go-ts-mode--keywords` and
`go-ts-mode--builtin-functions', but there is no variable for `go-constants`.
Note that the lists are marked as private.

The list of Go identifiers is relatively stable.  Since 2012 only Go 1.18 in
2022 and Go 1.21 in 2023 added new ones.

Given the above I have decided to hardcode list of Go keywords, constants, and
builtins.  This is basically the same list as `go-mode-1.6` and Emacs' 31
`go-ts-mode` use, but I have taken a liberty and added `any` and `comparable`
to it.