### PR TITLE
fix: remove brittle 'called-interactively-p' check

### DIFF
--- a/symbol-overlay.el
+++ b/symbol-overlay.el
@@ -607,8 +607,7 @@ When called interactively, then also reset
   (interactive)
   (unless (minibufferp)
     (mapc 'delete-overlay (symbol-overlay-get-list 0))
-    (when (called-interactively-p 'any)
-      (setq symbol-overlay-keywords-alist nil))))
+    (setq symbol-overlay-keywords-alist nil)))
 
 (add-hook 'before-revert-hook #'symbol-overlay-remove-all)
 


### PR DESCRIPTION
When executing Emacs in terminal the call to (called-interactively-p 'any) fails and prevents the list of overlays references from being cleared when invoking 'symbol-overlay-remove-all'. This in turn forces the user to toggle twice the overlay on a previously overlaid symbol, as the toggle function reliably removes the overlay from the list of applied overlays.

Remove the unneeded 'called-interactively-p' call.